### PR TITLE
Fix teleporting issue(s)

### DIFF
--- a/Components/BotComponentSpace/Classes/Mover/SAINMoverClass.cs
+++ b/Components/BotComponentSpace/Classes/Mover/SAINMoverClass.cs
@@ -152,11 +152,14 @@ namespace SAIN.SAINComponent.Classes.Mover
                 return;
             }
             Vector3 position = Bot.Position;
-            if ((_prevLinkPos - position).sqrMagnitude > 0f)
+            if ((_prevLinkPos - position).sqrMagnitude > 0.01f)
             {
                 Vector3 castPoint = position + Vector3.up * 0.3f;
                 BotOwner.Mover.SetPlayerToNavMesh(castPoint);
                 _prevLinkPos = position;
+                
+                BotOwner.Mover.PositionOnWayInner = BotOwner.Mover.botOwner_0.Position;
+                BotOwner.Mover.botOwner_0.Mover.LocalAvoidance.DropOffset();
             }
         }
 


### PR DESCRIPTION
Seems to have been an issue with method_9 (previously method_1) now including some extra cleanup after the SetPlayerToNavMesh call

Adding this cleanup got the teleporting to all but entirely stop except for when the bots came across doors.
Replacing >0f with >0.01f (as method_9 also did) sorted out the door interactions from what my testing showed.