### PR TITLE
Brain Handling Improvements [SPT 3.11]

### DIFF
--- a/Components/BotComponentSpace/BotComponent.cs
+++ b/Components/BotComponentSpace/BotComponent.cs
@@ -17,6 +17,7 @@ using SAIN.SAINComponent.Classes.Talk;
 using SAIN.SAINComponent.Classes.WeaponFunction;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace SAIN.SAINComponent
@@ -375,13 +376,39 @@ namespace SAIN.SAINComponent
 
         private bool verifyBrain(PersonClass person)
         {
-            if (Info.Profile.IsPMC &&
-                person.AIInfo.BotOwner.Brain.BaseBrain.ShortName() != Brain.PMC.ToString())
+            string assignedBrainName = person?.AIInfo?.BotOwner?.Brain?.BaseBrain?.ShortName();
+
+            if (Info.Profile.IsPMC)
             {
-                Logger.LogAndNotifyError($"{BotOwner.name} is a PMC but does not have [PMC] Base Brain! Current Brain Assignment: [{person.AIInfo.BotOwner.Brain.BaseBrain.ShortName()}] : SAIN Server mod is either missing or another mod is overwriting it. Destroying SAIN for this bot...");
-                return false;
+                IEnumerable<string> allowedBrainNames = AIBrains.GetAllowedPMCBrains().Select(brain => brain.ToString());
+                return isAssignedBrainAllowed(assignedBrainName, allowedBrainNames, "PMC") ? true : false;
             }
+
+            if (Info.Profile.IsPlayerScav)
+            {
+                IEnumerable<string> allowedBrainNames = AIBrains.GetAllowedPlayerScavBrains().Select(brain => brain.ToString());
+                return isAssignedBrainAllowed(assignedBrainName, allowedBrainNames, "PlayerScav") ? true : false;
+            }
+
+            if (Info.Profile.IsScav)
+            {
+                IEnumerable<string> allowedBrainNames = AIBrains.GetAllowedScavBrains().Select(brain => brain.ToString());
+                return isAssignedBrainAllowed(assignedBrainName, allowedBrainNames, "Scav") ? true : false;
+            }
+
             return true;
+        }
+
+        private bool isAssignedBrainAllowed(string assignedBrainName, IEnumerable<string> allowedBrainNames, string botCategory)
+        {
+            if (allowedBrainNames.Contains(assignedBrainName))
+            {
+                return true;
+            }
+
+            Logger.LogAndNotifyError($"{BotOwner.name} is a ${botCategory} but does not have any of these BaseBrains: ${string.Join(", ", allowedBrainNames)}! Current Brain Assignment: [{assignedBrainName}] : SAIN Server mod is either missing or another mod is overwriting it. Destroying SAIN for this bot...");
+
+            return false;
         }
 
         private void OnDisable()

--- a/Components/BotComponentSpace/Classes/Info/BotProfile.cs
+++ b/Components/BotComponentSpace/Classes/Info/BotProfile.cs
@@ -12,7 +12,6 @@ namespace SAIN.SAINComponent.Classes.Info
 
             var profile = sain.BotOwner.Profile;
             Side = profile.Side;
-            NickName = profile.Nickname;
             WildSpawnType = profile.Info.Settings.Role;
             BotDifficulty = profile.Info.Settings.BotDifficulty;
             PlayerLevel = profile.Info.Level;
@@ -21,7 +20,7 @@ namespace SAIN.SAINComponent.Classes.Info
             IsFollower = EnumValues.WildSpawn.IsFollower(WildSpawnType);
             IsScav = EnumValues.WildSpawn.IsScav(WildSpawnType);
             IsPMC = EnumValues.WildSpawn.IsPMC(WildSpawnType);
-            IsPlayerScav = IsScav && SAINEnableClass.IsPlayerScav(NickName);
+            IsPlayerScav = IsScav && SAINEnableClass.IsPlayerScav(profile);
             SetDiffModifier(BotDifficulty);
         }
 

--- a/Plugin/BigBrainHandler.cs
+++ b/Plugin/BigBrainHandler.cs
@@ -1,19 +1,76 @@
 ﻿using DrakiaXYZ.BigBrain.Brains;
+using EFT;
 using SAIN.Layers;
 using SAIN.Layers.Combat.Run;
 using SAIN.Layers.Combat.Solo;
 using SAIN.Layers.Combat.Squad;
 using SAIN.Preset.GlobalSettings;
 using SAIN.Preset.GlobalSettings.Categories;
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 
 namespace SAIN
 {
     public class BigBrainHandler
     {
+        public const bool INCLUDE_RAIDER_BRAIN_FOR_PMCS = true;
+
+        private static readonly string[] commonVanillaLayersToRemove = new string[]
+        {
+            "Help",
+            "AdvAssaultTarget",
+            "Hit",
+            "Simple Target",
+            "Pmc",
+            "AssaultHaveEnemy",
+            "Assault Building",
+            "Enemy Building",
+        };
+
+        private static List<Type> _SAINLayers = new List<Type>();
+        private static List<string> _SAINLayerNames = new List<string>();
+
+        public static List<string> SAINLayerNames => findAllSAINLayers();
+        public static List<Type> SAINLayers
+        {
+            get
+            {
+                if (_SAINLayers.Count == 0)
+                {
+                    _SAINLayers.AddRange(typeof(SAINPlugin).Assembly.GetTypes()
+                        .Where(type => type.IsSubclassOf(typeof(SAINLayer))));
+                }
+
+                return _SAINLayers;
+            }
+        }
+
         public static void Init()
         {
             BrainAssignment.Init();
+        }
+        private static List<string> findAllSAINLayers()
+        {
+            if (_SAINLayerNames.Count != 0)
+            {
+                return _SAINLayerNames;
+            }
+
+            foreach (Type layerType in SAINLayers)
+            {
+                FieldInfo nameFieldInfo = layerType.GetField("Name", BindingFlags.Public | BindingFlags.Static);
+                if (nameFieldInfo == null)
+                {
+                    Logger.LogError($"{layerType.Name} does not have a public static Name field. This is required for enabling vanilla layers!");
+                    continue;
+                }
+
+                _SAINLayerNames.Add((string)nameFieldInfo.GetValue(null));
+            }
+
+            return _SAINLayerNames;
         }
 
         public static bool BigBrainInitialized;
@@ -22,21 +79,232 @@ namespace SAIN
         {
             public static void Init()
             {
-                HandlePMCandRaiders();
-                HandleScavs();
-                HandleRogues();
-                HandleBloodHounds();
-                HandleBosses();
-                HandleFollowers();
-                HandleGoons();
-                HandleOthers();
+                addCustomLayersToPMCs();
+                addCustomLayersToScavs();
+                addCustomLayersToRaiders(new List<WildSpawnType>() { WildSpawnType.pmcBot });
+                addCustomLayersToRogues();
+                addCustomLayersToBloodHounds();
+                addCustomLayersToBosses();
+                addCustomLayersToFollowers();
+                addCustomLayersToGoons();
+                addCustomLayersToOthers();
+
+                ToggleVanillaLayersForPMCs(false);
+                ToggleVanillaLayersForOthers(false);
+                ToggleVanillaLayersForAllBots();
             }
 
-            private static void HandlePMCandRaiders()
+            public static void ToggleVanillaLayersForAllBots()
             {
+                ToggleVanillaLayersForScavs(_vanillaBotSettings.VanillaScavs);
+                ToggleVanillaLayersForRogues(_vanillaBotSettings.VanillaRogues);
+                ToggleVanillaLayersForRaiders(new List<WildSpawnType>() { WildSpawnType.pmcBot }, false); // _vanillaBotSettings.VanillaRaiders);
+                ToggleVanillaLayersForBloodHounds(_vanillaBotSettings.VanillaBloodHounds);
+                ToggleVanillaLayersForBosses(_vanillaBotSettings.VanillaBosses);
+                ToggleVanillaLayersForFollowers(_vanillaBotSettings.VanillaFollowers);
+                ToggleVanillaLayersForGoons(_vanillaBotSettings.VanillaGoons);
+            }
+
+            public static void ToggleVanillaLayersForPMCs(bool useVanillaLayers)
+            {
+                List<string> brainList = getBrainList(AIBrains.PMCs);
+
+                List<string> LayersToToggle = new List<string>
+                {
+                    "Request",
+                    //"FightReqNull",
+                    //"PeacecReqNull",
+                    "KnightFight",
+                    //"PtrlBirdEye",
+					"PmcBear",
+                    "PmcUsec",
+                };
+                LayersToToggle.AddRange(commonVanillaLayersToRemove);
+
+                toggleVanillaLayers(brainList, LayersToToggle, useVanillaLayers);
+
+                if (INCLUDE_RAIDER_BRAIN_FOR_PMCS)
+                {
+                    ToggleVanillaLayersForRaiders(new List<WildSpawnType>() { WildSpawnType.pmcBEAR, WildSpawnType.pmcUSEC }, useVanillaLayers);
+                }
+            }
+
+            public static void ToggleVanillaLayersForScavs(bool useVanillaLayers)
+            {
+                List<string> brainList = getBrainList(AIBrains.Scavs);
+
+                List<string> LayersToToggle = new List<string>
+                {
+                    //"FightReqNull",
+                    //"PeacecReqNull",
+                    "PmcBear",
+                    "PmcUsec",
+                };
+                LayersToToggle.AddRange(commonVanillaLayersToRemove);
+
+                toggleVanillaLayers(brainList, LayersToToggle, useVanillaLayers);
+
+                ToggleVanillaLayersForRaiders(new List<WildSpawnType>() { WildSpawnType.assaultGroup }, useVanillaLayers);
+            }
+
+            public static void ToggleVanillaLayersForRaiders(List<WildSpawnType> roles, bool useVanillaLayers)
+            {
+                List<string> brainList = new List<string>() { Brain.PMC.ToString() };
+
+                List<string> LayersToToggle = new List<string>
+                {
+                    "Request",
+                    //"FightReqNull",
+                    //"PeacecReqNull",
+                    "KnightFight",
+                    //"PtrlBirdEye",
+					"PmcBear",
+                    "PmcUsec",
+                };
+                LayersToToggle.AddRange(commonVanillaLayersToRemove);
+
+                toggleVanillaLayers(brainList, LayersToToggle, roles, useVanillaLayers);
+            }
+
+            public static void ToggleVanillaLayersForOthers(bool useVanillaLayers)
+            {
+                List<string> brainList = getBrainList(AIBrains.Others);
+
+                List<string> LayersToToggle = new List<string>
+                {
+                    "Request",
+                    //"FightReqNull",
+                    //"PeacecReqNull",
+                    "KnightFight",
+                    //"PtrlBirdEye",
+					"PmcBear",
+                    "PmcUsec",
+                };
+                LayersToToggle.AddRange(commonVanillaLayersToRemove);
+
+                toggleVanillaLayers(brainList, LayersToToggle, useVanillaLayers);
+            }
+
+            public static void ToggleVanillaLayersForRogues(bool useVanillaLayers)
+            {
+                List<string> brainList = new List<string>() { Brain.ExUsec.ToString() };
+
+                List<string> LayersToToggle = new List<string>
+                {
+                    "Request",
+                    //"FightReqNull",
+                    //"PeacecReqNull",
+                    "KnightFight",
+                    //"PtrlBirdEye",
+					"PmcBear",
+                    "PmcUsec",
+                };
+                LayersToToggle.AddRange(commonVanillaLayersToRemove);
+
+                toggleVanillaLayers(brainList, LayersToToggle, useVanillaLayers);
+            }
+
+            public static void ToggleVanillaLayersForBloodHounds(bool useVanillaLayers)
+            {
+                List<string> brainList = new List<string>() { Brain.ArenaFighter.ToString() };
+
+                List<string> LayersToToggle = new List<string>
+                {
+                    "Request",
+                    //"FightReqNull",
+                    //"PeacecReqNull",
+                    "KnightFight",
+                    //"PtrlBirdEye",
+					"PmcBear",
+                    "PmcUsec",
+                };
+                LayersToToggle.AddRange(commonVanillaLayersToRemove);
+
+                toggleVanillaLayers(brainList, LayersToToggle, useVanillaLayers);
+            }
+
+            public static void ToggleVanillaLayersForBosses(bool useVanillaLayers)
+            {
+                List<string> brainList = getBrainList(AIBrains.Bosses);
+
+                List<string> LayersToToggle = new List<string>
+                {
+                    "KnightFight",
+                    "BirdEyeFight",
+                    "BossBoarFight"
+                };
+                LayersToToggle.AddRange(commonVanillaLayersToRemove);
+
+                toggleVanillaLayers(brainList, LayersToToggle, useVanillaLayers);
+            }
+
+            public static void ToggleVanillaLayersForFollowers(bool useVanillaLayers)
+            {
+                List<string> brainList = getBrainList(AIBrains.Followers);
+
+                List<string> LayersToToggle = new List<string>
+                {
+                    "KnightFight",
+                    "BoarGrenadeDanger"
+                };
+                LayersToToggle.AddRange(commonVanillaLayersToRemove);
+
+                toggleVanillaLayers(brainList, LayersToToggle, useVanillaLayers);
+            }
+
+            public static void ToggleVanillaLayersForGoons(bool useVanillaLayers)
+            {
+                List<string> brainList = getBrainList(AIBrains.Goons);
+
+                List<string> LayersToToggle = new List<string>
+                {
+                    //"FightReqNull",
+                    //"PeacecReqNull",
+                    "KnightFight",
+                    "BirdEyeFight",
+                    "Kill logic"
+                };
+                LayersToToggle.AddRange(commonVanillaLayersToRemove);
+
+                toggleVanillaLayers(brainList, LayersToToggle, useVanillaLayers);
+            }
+
+            private static void toggleVanillaLayers(List<string> brainNames, List<string> layerNames, bool useVanillaLayers)
+            {
+                if (useVanillaLayers)
+                {
+                    BrainManager.RemoveLayers(SAINLayerNames, brainNames);
+                    BrainManager.RestoreLayers(layerNames, brainNames);
+                }
+                else
+                {
+                    checkExtractEnabled(layerNames);
+
+                    BrainManager.RestoreLayers(SAINLayerNames, brainNames);
+                    BrainManager.RemoveLayers(layerNames, brainNames);
+                }
+            }
+
+            private static void toggleVanillaLayers(List<string> brainNames, List<string> layerNames, List<WildSpawnType> roles, bool useVanillaLayers)
+            {
+                if (useVanillaLayers)
+                {
+                    BrainManager.RemoveLayers(SAINLayerNames, brainNames, roles);
+                    BrainManager.RestoreLayers(layerNames, brainNames, roles);
+                }
+                else
+                {
+                    checkExtractEnabled(layerNames);
+
+                    BrainManager.RestoreLayers(SAINLayerNames, brainNames, roles);
+                    BrainManager.RemoveLayers(layerNames, brainNames, roles);
+                }
+            }
+
+            private static void addCustomLayersToPMCs()
+            {
+                List<string> pmcBrain = getBrainList(AIBrains.PMCs);
                 var settings = SAINPlugin.LoadedPreset.GlobalSettings.General.Layers;
-                List<string> pmcBrain = new();
-                pmcBrain.Add(Brain.PMC.ToString());
 
                 BrainManager.AddCustomLayer(typeof(DebugLayer), pmcBrain, 99);
                 BrainManager.AddCustomLayer(typeof(SAINAvoidThreatLayer), pmcBrain, 80);
@@ -44,36 +312,15 @@ namespace SAIN
                 BrainManager.AddCustomLayer(typeof(CombatSquadLayer), pmcBrain, settings.SAINCombatSquadLayerPriority);
                 BrainManager.AddCustomLayer(typeof(CombatSoloLayer), pmcBrain, settings.SAINCombatSoloLayerPriority);
 
-                List<string> LayersToRemove = new()
+                if (INCLUDE_RAIDER_BRAIN_FOR_PMCS)
                 {
-                    "Help",
-                    "AdvAssaultTarget",
-                    "Hit",
-                    "Simple Target",
-                    "Pmc",
-                    "AssaultHaveEnemy",
-                    "Request",
-                    //"FightReqNull",
-                    //"PeacecReqNull",
-                    "Assault Building",
-                    "Enemy Building",
-                    "KnightFight",
-                    //"PtrlBirdEye",
-                    "PmcBear",
-                    "PmcUsec",
-                };
-                CheckExtractEnabled(LayersToRemove);
-                BrainManager.RemoveLayers(LayersToRemove, pmcBrain);
+                    addCustomLayersToRaiders(new List<WildSpawnType>() { WildSpawnType.pmcBEAR, WildSpawnType.pmcUSEC });
+                }
             }
 
-            private static void HandleScavs()
+            private static void addCustomLayersToScavs()
             {
-                if (_vanillaBotSettings.VanillaScavs)
-                {
-                    return;
-                }
-
-                List<string> brainList = GetBrainList(AIBrains.Scavs);
+                List<string> brainList = getBrainList(AIBrains.Scavs);
                 var settings = SAINPlugin.LoadedPreset.GlobalSettings.General.Layers;
 
                 //BrainManager.AddCustomLayer(typeof(BotUnstuckLayer), stringList, 98);
@@ -83,28 +330,24 @@ namespace SAIN
                 BrainManager.AddCustomLayer(typeof(CombatSquadLayer), brainList, settings.SAINCombatSquadLayerPriority);
                 BrainManager.AddCustomLayer(typeof(CombatSoloLayer), brainList, settings.SAINCombatSoloLayerPriority);
 
-                List<string> LayersToRemove = new()
-                {
-                    "Help",
-                    "AdvAssaultTarget",
-                    "Hit",
-                    "Simple Target",
-                    "Pmc",
-                    //"FightReqNull",
-                    //"PeacecReqNull",
-                    "AssaultHaveEnemy",
-                    "Assault Building",
-                    "Enemy Building",
-                    "PmcBear",
-                    "PmcUsec",
-                };
-                CheckExtractEnabled(LayersToRemove);
-                BrainManager.RemoveLayers(LayersToRemove, brainList);
+                addCustomLayersToRaiders(new List<WildSpawnType>() { WildSpawnType.assaultGroup });
             }
 
-            private static void HandleOthers()
+            private static void addCustomLayersToRaiders(List<WildSpawnType> roles)
             {
-                List<string> brainList = GetBrainList(AIBrains.Others);
+                var settings = SAINPlugin.LoadedPreset.GlobalSettings.General.Layers;
+                List<string> raiderBrain = new List<string>() { Brain.PMC.ToString() };
+
+                BrainManager.AddCustomLayer(typeof(DebugLayer), raiderBrain, 99, roles);
+                BrainManager.AddCustomLayer(typeof(SAINAvoidThreatLayer), raiderBrain, 80, roles);
+                BrainManager.AddCustomLayer(typeof(ExtractLayer), raiderBrain, settings.SAINExtractLayerPriority, roles);
+                BrainManager.AddCustomLayer(typeof(CombatSquadLayer), raiderBrain, settings.SAINCombatSquadLayerPriority, roles);
+                BrainManager.AddCustomLayer(typeof(CombatSoloLayer), raiderBrain, settings.SAINCombatSoloLayerPriority, roles);
+            }
+
+            private static void addCustomLayersToOthers()
+            {
+                List<string> brainList = getBrainList(AIBrains.Others);
 
                 var settings = SAINPlugin.LoadedPreset.GlobalSettings.General.Layers;
                 //BrainManager.AddCustomLayer(typeof(BotUnstuckLayer), stringList, 98);
@@ -113,37 +356,11 @@ namespace SAIN
                 BrainManager.AddCustomLayer(typeof(ExtractLayer), brainList, settings.SAINExtractLayerPriority);
                 BrainManager.AddCustomLayer(typeof(CombatSquadLayer), brainList, settings.SAINCombatSquadLayerPriority);
                 BrainManager.AddCustomLayer(typeof(CombatSoloLayer), brainList, settings.SAINCombatSoloLayerPriority);
-
-                List<string> LayersToRemove = new()
-                {
-                    "Help",
-                    "AdvAssaultTarget",
-                    "Hit",
-                    "Simple Target",
-                    "Pmc",
-                    "AssaultHaveEnemy",
-                    "Request",
-                    //"FightReqNull",
-                    //"PeacecReqNull",
-                    "Assault Building",
-                    "Enemy Building",
-                    "KnightFight",
-                    //"PtrlBirdEye",
-                    "PmcBear",
-                    "PmcUsec",
-                };
-                CheckExtractEnabled(LayersToRemove);
-                BrainManager.RemoveLayers(LayersToRemove, brainList);
             }
 
-            private static void HandleRogues()
+            private static void addCustomLayersToRogues()
             {
-                if (_vanillaBotSettings.VanillaRogues)
-                {
-                    return;
-                }
-
-                List<string> brainList = new();
+                List<string> brainList = new List<string>();
                 brainList.Add(Brain.ExUsec.ToString());
 
                 var settings = SAINPlugin.LoadedPreset.GlobalSettings.General.Layers;
@@ -153,37 +370,11 @@ namespace SAIN
                 BrainManager.AddCustomLayer(typeof(ExtractLayer), brainList, settings.SAINExtractLayerPriority);
                 BrainManager.AddCustomLayer(typeof(CombatSquadLayer), brainList, settings.SAINCombatSquadLayerPriority);
                 BrainManager.AddCustomLayer(typeof(CombatSoloLayer), brainList, settings.SAINCombatSoloLayerPriority);
-
-                List<string> LayersToRemove = new()
-                {
-                    "Help",
-                    "AdvAssaultTarget",
-                    "Hit",
-                    "Simple Target",
-                    "Pmc",
-                    "AssaultHaveEnemy",
-                    "Request",
-                    //"FightReqNull",
-                    //"PeacecReqNull",
-                    "Assault Building",
-                    "Enemy Building",
-                    "KnightFight",
-                    //"PtrlBirdEye",
-                    "PmcBear",
-                    "PmcUsec",
-                };
-                CheckExtractEnabled(LayersToRemove);
-                BrainManager.RemoveLayers(LayersToRemove, brainList);
             }
 
-            private static void HandleBloodHounds()
+            private static void addCustomLayersToBloodHounds()
             {
-                if (_vanillaBotSettings.VanillaBloodHounds)
-                {
-                    return;
-                }
-
-                List<string> brainList = new();
+                List<string> brainList = new List<string>();
                 brainList.Add(Brain.ArenaFighter.ToString());
 
                 var settings = SAINPlugin.LoadedPreset.GlobalSettings.General.Layers;
@@ -193,37 +384,11 @@ namespace SAIN
                 BrainManager.AddCustomLayer(typeof(ExtractLayer), brainList, settings.SAINExtractLayerPriority);
                 BrainManager.AddCustomLayer(typeof(CombatSquadLayer), brainList, settings.SAINCombatSquadLayerPriority);
                 BrainManager.AddCustomLayer(typeof(CombatSoloLayer), brainList, settings.SAINCombatSoloLayerPriority);
-
-                List<string> LayersToRemove = new()
-                {
-                    "Help",
-                    "AdvAssaultTarget",
-                    "Hit",
-                    "Simple Target",
-                    "Pmc",
-                    "AssaultHaveEnemy",
-                    "Request",
-                    //"FightReqNull",
-                    //"PeacecReqNull",
-                    "Assault Building",
-                    "Enemy Building",
-                    "KnightFight",
-                    //"PtrlBirdEye",
-                    "PmcBear",
-                    "PmcUsec",
-                };
-                CheckExtractEnabled(LayersToRemove);
-                BrainManager.RemoveLayers(LayersToRemove, brainList);
             }
 
-            private static void HandleBosses()
+            private static void addCustomLayersToBosses()
             {
-                if (_vanillaBotSettings.VanillaBosses)
-                {
-                    return;
-                }
-
-                List<string> brainList = GetBrainList(AIBrains.Bosses);
+                List<string> brainList = getBrainList(AIBrains.Bosses);
 
                 var settings = SAINPlugin.LoadedPreset.GlobalSettings.General;
                 //BrainManager.AddCustomLayer(typeof(BotUnstuckLayer), stringList, 98);
@@ -231,33 +396,11 @@ namespace SAIN
                 BrainManager.AddCustomLayer(typeof(SAINAvoidThreatLayer), brainList, 80);
                 BrainManager.AddCustomLayer(typeof(CombatSquadLayer), brainList, 70);
                 BrainManager.AddCustomLayer(typeof(CombatSoloLayer), brainList, 69);
-
-                List<string> LayersToRemove = new()
-                {
-                    "Help",
-                    "AdvAssaultTarget",
-                    "Hit",
-                    "Simple Target",
-                    "Pmc",
-                    "AssaultHaveEnemy",
-                    "Assault Building",
-                    "Enemy Building",
-                    "KnightFight",
-                    "BirdEyeFight",
-                    "BossBoarFight"
-                };
-                CheckExtractEnabled(LayersToRemove);
-                BrainManager.RemoveLayers(LayersToRemove, brainList);
             }
 
-            private static void HandleFollowers()
+            private static void addCustomLayersToFollowers()
             {
-                if (_vanillaBotSettings.VanillaFollowers)
-                {
-                    return;
-                }
-
-                List<string> brainList = GetBrainList(AIBrains.Followers);
+                List<string> brainList = getBrainList(AIBrains.Followers);
 
                 var settings = SAINPlugin.LoadedPreset.GlobalSettings.General;
                 //BrainManager.AddCustomLayer(typeof(BotUnstuckLayer), stringList, 98);
@@ -265,59 +408,19 @@ namespace SAIN
                 BrainManager.AddCustomLayer(typeof(SAINAvoidThreatLayer), brainList, 80);
                 BrainManager.AddCustomLayer(typeof(CombatSquadLayer), brainList, 70);
                 BrainManager.AddCustomLayer(typeof(CombatSoloLayer), brainList, 69);
-
-                List<string> LayersToRemove = new()
-                {
-                    "Help",
-                    "AdvAssaultTarget",
-                    "Hit",
-                    "Simple Target",
-                    "Pmc",
-                    "AssaultHaveEnemy",
-                    "Assault Building",
-                    "Enemy Building",
-                    "KnightFight",
-                    "BoarGrenadeDanger"
-                };
-                CheckExtractEnabled(LayersToRemove);
-                BrainManager.RemoveLayers(LayersToRemove, brainList);
             }
 
-            private static void HandleGoons()
+            private static void addCustomLayersToGoons()
             {
-                if (_vanillaBotSettings.VanillaGoons)
-                {
-                    return;
-                }
-
-                List<string> brainList = GetBrainList(AIBrains.Goons);
+                List<string> brainList = getBrainList(AIBrains.Goons);
 
                 BrainManager.AddCustomLayer(typeof(DebugLayer), brainList, 99);
                 BrainManager.AddCustomLayer(typeof(SAINAvoidThreatLayer), brainList, 80);
                 BrainManager.AddCustomLayer(typeof(CombatSquadLayer), brainList, 64);
                 BrainManager.AddCustomLayer(typeof(CombatSoloLayer), brainList, 62);
-
-                List<string> LayersToRemove = new()
-                {
-                    "Help",
-                    "AdvAssaultTarget",
-                    "Hit",
-                    "Simple Target",
-                    "Pmc",
-                    "AssaultHaveEnemy",
-                    //"FightReqNull",
-                    //"PeacecReqNull",
-                    "Assault Building",
-                    "Enemy Building",
-                    "KnightFight",
-                    "BirdEyeFight",
-                    "Kill logic"
-                };
-                CheckExtractEnabled(LayersToRemove);
-                BrainManager.RemoveLayers(LayersToRemove, brainList);
             }
 
-            private static void CheckExtractEnabled(List<string> layersToRemove)
+            private static void checkExtractEnabled(List<string> layersToRemove)
             {
                 if (GlobalSettingsClass.Instance.General.Extract.SAIN_EXTRACT_TOGGLE)
                 {
@@ -325,9 +428,9 @@ namespace SAIN
                 }
             }
 
-            private static List<string> GetBrainList(List<Brain> brains)
+            private static List<string> getBrainList(List<Brain> brains)
             {
-                List<string> brainList = new();
+                List<string> brainList = new List<string>();
                 for (int i = 0; i < brains.Count; i++)
                 {
                     brainList.Add(brains[i].ToString());

--- a/Plugin/SAINEnableClass.cs
+++ b/Plugin/SAINEnableClass.cs
@@ -5,6 +5,7 @@ using SAIN.Preset.GlobalSettings;
 using SAIN.SAINComponent;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using UnityEngine.Profiling;
 using static SAIN.Helpers.EnumValues;
 
 namespace SAIN
@@ -136,7 +137,7 @@ namespace SAIN
         {
             return SAINEnabled.VanillaScavs
             && WildSpawn.IsScav(wildSpawnType) &&
-            !IsPlayerScav(botOwner.Profile.Nickname);
+            !IsPlayerScav(botOwner.Profile);
         }
 
         private static bool ExcludeOthers(WildSpawnType wildSpawnType)
@@ -168,16 +169,16 @@ namespace SAIN
             return false;
         }
 
-        public static bool IsPlayerScav(string nickname)
+        public static bool IsPlayerScav(Profile profile)
         {
-            // Pattern: xxx (xxx)
-            string pattern = "\\w+.[(]\\w+[)]";
-            Regex regex = new(pattern);
-            if (regex.Matches(nickname).Count > 0)
+            // Handle the old version of creating player Scavs
+            if (profile.Info.Nickname.Contains(" ("))
             {
                 return true;
             }
-            return false;
+
+            // Check for player Scavs created by SPT
+            return profile.Info.Settings.Role == WildSpawnType.assault && !string.IsNullOrEmpty(profile.Info.MainProfileNickname);
         }
 
         public static bool GetSAIN(BotOwner botOwner, out BotComponent sain)

--- a/Preset/GlobalSettings/Categories/BigBrain/Brain.cs
+++ b/Preset/GlobalSettings/Categories/BigBrain/Brain.cs
@@ -42,10 +42,40 @@ namespace SAIN.Preset.GlobalSettings.Categories
         SectantWarrior,
         CursAssault,
         Assault,
+        PmcBear,
+        PmcUsec,
     }
 
     public static class AIBrains
     {
+        public static List<Brain> GetAllowedScavBrains()
+        {
+            return Scavs;
+        }
+
+        public static List<Brain> GetAllowedPlayerScavBrains()
+        {
+            return GetAllowedPMCBrains();
+        }
+
+        public static List<Brain> GetAllowedPMCBrains()
+        {
+            List<Brain> PMCBrains = PMCs;
+
+            if (BigBrainHandler.INCLUDE_RAIDER_BRAIN_FOR_PMCS)
+            {
+                PMCBrains.Add(Brain.PMC);
+            }
+
+            return PMCBrains;
+        }
+
+        public static readonly List<Brain> PMCs = new List<Brain>
+        {
+            Brain.PmcBear,
+            Brain.PmcUsec,
+        };
+
         public static readonly List<Brain> Scavs = new()
         {
             Brain.CursAssault,

--- a/Preset/GlobalSettings/Categories/BigBrain/Brain.cs
+++ b/Preset/GlobalSettings/Categories/BigBrain/Brain.cs
@@ -50,7 +50,12 @@ namespace SAIN.Preset.GlobalSettings.Categories
     {
         public static List<Brain> GetAllowedScavBrains()
         {
-            return Scavs;
+            List<Brain> ScavBrains = Scavs;
+
+            // Needed for assaultGroup Scavs
+            ScavBrains.Add(Brain.PMC);
+
+            return ScavBrains;
         }
 
         public static List<Brain> GetAllowedPlayerScavBrains()
@@ -113,7 +118,6 @@ namespace SAIN.Preset.GlobalSettings.Categories
 
         public static readonly List<Brain> Followers = new()
         {
-            Brain.BossBully,
             Brain.FollowerBully,
             Brain.FollowerGluharAssault,
             Brain.FollowerGluharProtect,


### PR DESCRIPTION
**Improvements:**
* Enabling vanilla AI for Scavs now correctly prevents assaultGroup Scavs from using SAIN's brain layers
* Allow SAIN to be used for `PmcBEAR` and `PmcUSEC` brains
* Refactored `BigBrainHandler` to do the following:
    * In the future, allow Raider brains to be handled separately from `PMC` brains (requires PMC's to have `PmcBEAR` or `PmcUSEC` brains, which is too big of a change for right now)
    * In the future, allow vanilla AI to be toggled on/off during a raid (requires additional changes that are too significant for this PR)
    * Enumerate SAIN brain layers automatically when removing them (instead of needing to hardcode them)
    * Implemented common list of vanilla brain layers to remove from all bots for which SAIN is enabled
* Expanded `BotComponent.verifyBrain` check to include player Scavs and normal Scavs (because their brains are also specified by SAIN's server code)
 
**Fixes:**
* Fixed player Scav detection not working correctly in SPT 3.11 (especially when using the Questing Bots spawning system)
* Removed `BossBully` brain incorrectly added to list of follower brains