### PR TITLE
Link DebugMode to GlobalDebugMode [SPT 3.11]

### DIFF
--- a/Plugin/SAINPlugin.cs
+++ b/Plugin/SAINPlugin.cs
@@ -31,7 +31,7 @@ namespace SAIN
     public class SAINPlugin : BaseUnityPlugin
     {
         public static DebugSettings DebugSettings => LoadedPreset.GlobalSettings.General.Debug;
-        public static bool DebugMode => true;
+        public static bool DebugMode => DebugSettings.Logs.GlobalDebugMode;
         public static bool ProfilingMode => DebugSettings.Logs.GlobalProfilingToggle;
         public static bool DrawDebugGizmos => DebugSettings.Gizmos.DrawDebugGizmos;
         public static PresetEditorDefaults EditorDefaults => PresetHandler.EditorDefaults;


### PR DESCRIPTION
Instead of hard-coding `SAINPlugin.DebugMode` to be `true`, toggle it with `DebugSettings.Logs.GlobalDebugMode` (accessible via the F12 menu)